### PR TITLE
Tests refactor

### DIFF
--- a/server/src/core/thermostat.ts
+++ b/server/src/core/thermostat.ts
@@ -72,7 +72,7 @@ export class Thermostat implements IThermostat {
            this.stopTrigger();
         }
 		
-        if(this.isFirstRun() || Date.now() - this._stopTime.getTime() > this.configuration.minDelayBetweenRuns) {
+        if((this.isFirstRun() || Date.now() - this._stopTime.getTime() > this.configuration.minDelayBetweenRuns) && !this.isRunning()) {
             this._targetOvershootBy = Math.min(Math.abs(this.target - temp), this.configuration.maxOvershootTemp)
             this.startTrigger();
         }

--- a/server/src/core/thermostat.ts
+++ b/server/src/core/thermostat.ts
@@ -63,6 +63,7 @@ export class Thermostat implements IThermostat {
 
     stop() {
         this._tempReader.stop();
+		this.emitComplete();
 		this.emitEvent(ThermostatEventType.Message, ThermostatTopic.Status, 'Stopped');
     }
 


### PR DESCRIPTION
Tests are now more isolated. Dependencies are all mocked and don't depend on their functionality. Also most of the thermostat tests were converted to mock the obserable directly off the temp reader, so we now have access to the completed callback of it. In this callback assertions can be made and done() can be called so there's no chance of emitted values bleeding into other test runs like before.