### PR TITLE
Remove topic arrays

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -53,7 +53,7 @@ export class AppComponent implements OnInit {
 		if(!environment.production) {
 			//log all events to console for debugging
 			this.thermostatService.events$.subscribe((event) => {
-				console.log(`${event.topic.join('/')} : ${event.message}`);
+				console.log(`${event.topic} : ${event.message}`);
 			});
 		}
 

--- a/client/src/app/thermostat.service.ts
+++ b/client/src/app/thermostat.service.ts
@@ -5,7 +5,7 @@ import * as _ from 'lodash';
 
 import { AppConfig, APP_CONFIG } from '../app.config';
 import { ThermostatMode } from '../../../common/thermostatMode';
-import { IThermostatEvent, ThermostatEventType, ThermostatTopic } from '../../../common/thermostatEvent';
+import { IThermostatEvent, ThermostatEventType, THERMOSTAT_TOPIC } from '../../../common/thermostatEvent';
 
 @Injectable()
 export class ThermostatService {
@@ -27,13 +27,13 @@ export class ThermostatService {
 			this.socket.on('message', (message) => observer.next(message));
 		});
 
-		this.temperature$ = this.events$.filter((event: IThermostatEvent) => _.isEqual(event.topic, ThermostatTopic.Temperature))
+		this.temperature$ = this.events$.filter((event: IThermostatEvent) => _.isEqual(event.topic, THERMOSTAT_TOPIC.Temperature))
 										.map((event: IThermostatEvent): number => parseFloat(event.message));
 
-		this.target$ = this.events$.filter((event: IThermostatEvent) => _.isEqual(event.topic, ThermostatTopic.Target))
+		this.target$ = this.events$.filter((event: IThermostatEvent) => _.isEqual(event.topic, THERMOSTAT_TOPIC.Target))
 										.map((event: IThermostatEvent): number => parseFloat(event.message));
 
-		this.status$ = this.events$.filter((event: IThermostatEvent) => _.isEqual(event.topic, ThermostatTopic.Status))
+		this.status$ = this.events$.filter((event: IThermostatEvent) => _.isEqual(event.topic, THERMOSTAT_TOPIC.Status))
 									.map((event: IThermostatEvent): string => event.message);
 							
 		this.error$ = this.events$.filter((event: IThermostatEvent) => event.type == ThermostatEventType.Error)

--- a/common/thermostatEvent.ts
+++ b/common/thermostatEvent.ts
@@ -5,17 +5,17 @@ export enum ThermostatEventType {
 }
 
 export class ThermostatTopic {
-	static Temperature = ['sensors', 'temperature', 'thermostat'];
-	static Target = ['thermostat', 'target'];
-	static Mode = ['thermostat', 'mode'];
-	static Status = ['thermostat', 'status'];
-	static Furnace = ['thermostat', 'furnace'];
-	static Ac = ['thermostat', 'ac'];
-	static Error = ['thermostat', 'error'];
+	static Temperature = 'sensors/temperature/thermostat';
+	static Target = 'thermostat/target';
+	static Mode = 'thermostat/mode';
+	static Status = 'thermostat/status';
+	static Furnace = 'thermostat/furnace';
+	static Ac = 'thermostat/ac';
+	static Error = 'thermostat/error';
 }
 
 export interface IThermostatEvent {
     type: ThermostatEventType;
-    topic: Array<string>;
+    topic: string;
     message: string;
 }

--- a/common/thermostatEvent.ts
+++ b/common/thermostatEvent.ts
@@ -4,18 +4,26 @@ export enum ThermostatEventType {
     Warning
 }
 
-export class ThermostatTopic {
-	static Temperature = 'sensors/temperature/thermostat';
-	static Target = 'thermostat/target';
-	static Mode = 'thermostat/mode';
-	static Status = 'thermostat/status';
-	static Furnace = 'thermostat/furnace';
-	static Ac = 'thermostat/ac';
-	static Error = 'thermostat/error';
+class ThermostatTopic {
+	readonly Temperature = 'sensors/temperature/thermostat';
+	readonly Target = 'thermostat/target';
+	readonly TargetSet = 'thermostat/target/set';
+	readonly Mode = 'thermostat/mode';
+	readonly ModeSet = 'thermostat/mode/set';
+	readonly Status = 'thermostat/status';
+	readonly Furnace = 'thermostat/furnace';
+	readonly Ac = 'thermostat/ac';
+	readonly Error = 'thermostat/error';
+
+	allTopics(): string[] {
+		return Object.keys(this).map(key => this[key]);
+	}
 }
+
+export let THERMOSTAT_TOPIC: ThermostatTopic = new ThermostatTopic();
 
 export interface IThermostatEvent {
     type: ThermostatEventType;
     topic: string;
-    message: string;
+    message: any;
 }

--- a/server/src/api/broadcaster.ts
+++ b/server/src/api/broadcaster.ts
@@ -22,7 +22,7 @@ export class MqttBroadcaster implements IBroadcaster {
 	broadcast(event: IThermostatEvent) {
 		//TODO shouldn't need this truthy check, ordering is wrong
 		if(this._client) {
-			this._client.publish(event.topic.join('/'), event.message);
+			this._client.publish(event.topic, event.message);
 		}
 	}
 }

--- a/server/src/api/iotBridge.ts
+++ b/server/src/api/iotBridge.ts
@@ -27,9 +27,9 @@ export class MqttBridge implements IIoTBridge {
 
 		this.events$ = Rx.Observable.fromEvent(this._client, 'message', (topic, message) => <any>{topic, message})
 			.map((message) => <IThermostatEvent>{
-				topic: (<any>message).topic.split('/'),
+				topic: message.topic,
 				type: ThermostatEventType.Message,
-				message: (<any>message).message
+				message: JSON.parse(message.message)
 			}
 		);
 	}

--- a/server/src/api/iotBridge.ts
+++ b/server/src/api/iotBridge.ts
@@ -1,7 +1,7 @@
 import Rx = require('rxjs');
 import * as mqtt from 'mqtt';
 
-import { IThermostatEvent, ThermostatEventType } from '../../../common/thermostatEvent';
+import { IThermostatEvent, ThermostatEventType, THERMOSTAT_TOPIC } from '../../../common/thermostatEvent';
 
 export class IIoTBridge {
 	connect: () => void;
@@ -22,7 +22,9 @@ export class MqttBridge implements IIoTBridge {
 		});
 
 		this._client.on('connect', () => {
-			this._client.subscribe('thermostat/#');
+			THERMOSTAT_TOPIC.allTopics().forEach((topic) => {
+				this._client.subscribe(topic);
+			});
 		});
 
 		this.events$ = Rx.Observable.fromEvent(this._client, 'message', (topic, message) => <any>{topic, message})

--- a/server/src/api/thermostatServer.tests.ts
+++ b/server/src/api/thermostatServer.tests.ts
@@ -109,7 +109,7 @@ describe('Thermostat Server Spec', () => {
 		mockEventStream.next(event);
 
 		sinon.assert.calledOnce(<any>mockIoTBridge.broadcast);
-		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic.join('/'), {
+		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic, {
 			temperature: parseInt(event.message)
 		});
 	});
@@ -124,7 +124,7 @@ describe('Thermostat Server Spec', () => {
 		mockEventStream.next(event);
 
 		sinon.assert.calledOnce(<any>mockIoTBridge.broadcast);
-		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic.join('/'), {
+		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic, {
 			target: parseInt(event.message)
 		});
 	});
@@ -138,7 +138,7 @@ describe('Thermostat Server Spec', () => {
 		mockEventStream.next(event);
 
 		sinon.assert.calledOnce(<any>mockIoTBridge.broadcast);
-		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic.join('/'), {
+		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic, {
 			mode: event.message
 		});
 	});
@@ -152,7 +152,7 @@ describe('Thermostat Server Spec', () => {
 		mockEventStream.next(event);
 
 		sinon.assert.calledOnce(<any>mockIoTBridge.broadcast);
-		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic.join('/'), {
+		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic, {
 			status: event.message
 		});
 	});
@@ -166,7 +166,7 @@ describe('Thermostat Server Spec', () => {
 		mockEventStream.next(event);
 
 		sinon.assert.calledOnce(<any>mockIoTBridge.broadcast);
-		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic.join('/'), {
+		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic, {
 			action: event.message
 		});
 	});
@@ -180,7 +180,7 @@ describe('Thermostat Server Spec', () => {
 		mockEventStream.next(event);
 
 		sinon.assert.calledOnce(<any>mockIoTBridge.broadcast);
-		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic.join('/'), {
+		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic, {
 			action: event.message
 		});
 	});
@@ -194,7 +194,7 @@ describe('Thermostat Server Spec', () => {
 		mockEventStream.next(event);
 
 		sinon.assert.calledOnce(<any>mockIoTBridge.broadcast);
-		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic.join('/'), {
+		sinon.assert.calledWith(<any>mockIoTBridge.broadcast, event.topic, {
 			error: event.message
 		});
 	});

--- a/server/src/api/thermostatServer.tests.ts
+++ b/server/src/api/thermostatServer.tests.ts
@@ -4,7 +4,7 @@ import { Subject } from 'rxjs';
 
 import { ThermostatMode } from '../../../common/thermostatMode';
 import { IThermostatEvent, ThermostatEventType } from '../../../common/thermostatEvent';
-import { ThermostatTopic } from '../../../common/thermostatEvent';
+import { THERMOSTAT_TOPIC } from '../../../common/thermostatEvent';
 
 import { IThermostat } from '../core/thermostat';
 
@@ -103,7 +103,7 @@ describe('Thermostat Server Spec', () => {
 	it('should broadcast thermostat temperature events as an object', () => {
 		let event: IThermostatEvent = {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Temperature,
+			topic: THERMOSTAT_TOPIC.Temperature,
 			message: '72'
 		};
 		mockEventStream.next(event);
@@ -118,7 +118,7 @@ describe('Thermostat Server Spec', () => {
 	it('should broadcast thermostat target events as an object', () => {
 		let event: IThermostatEvent = {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Target,
+			topic: THERMOSTAT_TOPIC.Target,
 			message: '68'
 		};
 		mockEventStream.next(event);
@@ -132,7 +132,7 @@ describe('Thermostat Server Spec', () => {
 	it('should broadcast thermostat mode events as an object', () => {
 		let event: IThermostatEvent = {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Mode,
+			topic: THERMOSTAT_TOPIC.Mode,
 			message: ThermostatMode.Cooling.toString()
 		};
 		mockEventStream.next(event);
@@ -146,7 +146,7 @@ describe('Thermostat Server Spec', () => {
 	it('should broadcast thermostat status events as an object', () => {
 		let event: IThermostatEvent = {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Status,
+			topic: THERMOSTAT_TOPIC.Status,
 			message: 'some status message'
 		};
 		mockEventStream.next(event);
@@ -160,7 +160,7 @@ describe('Thermostat Server Spec', () => {
 	it('should broadcast thermostat furnace events as an object', () => {
 		let event: IThermostatEvent = {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Furnace,
+			topic: THERMOSTAT_TOPIC.Furnace,
 			message: 'on'
 		};
 		mockEventStream.next(event);
@@ -174,7 +174,7 @@ describe('Thermostat Server Spec', () => {
 	it('should broadcast thermostat AC events as an object', () => {
 		let event: IThermostatEvent = {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Ac,
+			topic: THERMOSTAT_TOPIC.Ac,
 			message: 'on'
 		};
 		mockEventStream.next(event);
@@ -188,7 +188,7 @@ describe('Thermostat Server Spec', () => {
 	it('should broadcast error events as an object', () => {
 		let event: IThermostatEvent = {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Error,
+			topic: THERMOSTAT_TOPIC.Error,
 			message: 'some error'
 		};
 		mockEventStream.next(event);
@@ -204,7 +204,7 @@ describe('Thermostat Server Spec', () => {
 		let incomingMode = ThermostatMode.Cooling;
 
 		(<Subject<IThermostatEvent>>mockIoTBridge.events$).next({
-			topic: ThermostatTopic.Target,
+			topic: THERMOSTAT_TOPIC.Target,
 			type: ThermostatEventType.Message,
 			message: incomingTarget.toString()
 		});
@@ -212,7 +212,7 @@ describe('Thermostat Server Spec', () => {
 		sinon.assert.calledWith(<any>mockThermostat.setTarget, incomingTarget);
 
 		(<Subject<IThermostatEvent>>mockIoTBridge.events$).next({
-			topic: ThermostatTopic.Mode,
+			topic: THERMOSTAT_TOPIC.Mode,
 			type: ThermostatEventType.Message,
 			message: incomingMode.toString()
 		});
@@ -224,19 +224,19 @@ describe('Thermostat Server Spec', () => {
 		let temperature = 73;
 		mockEventStream.next({ //need to push a temperature through before we can get it back out
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Temperature,
+			topic: THERMOSTAT_TOPIC.Temperature,
 			message: temperature.toString(),
 		});
 		onConnectionCallback(mockSocket);
 
 		sinon.assert.calledWith(mockSocket.send, {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Target,
+			topic: THERMOSTAT_TOPIC.Target,
 			message: mockThermostat.target.toString(),
 		});
 		sinon.assert.calledWith(mockSocket.send, {
 			type: ThermostatEventType.Message,
-			topic: ThermostatTopic.Temperature,
+			topic: THERMOSTAT_TOPIC.Temperature,
 			message: temperature.toString(),
 		});
 	});

--- a/server/src/api/thermostatServer.tests.ts
+++ b/server/src/api/thermostatServer.tests.ts
@@ -204,17 +204,21 @@ describe('Thermostat Server Spec', () => {
 		let incomingMode = ThermostatMode.Cooling;
 
 		(<Subject<IThermostatEvent>>mockIoTBridge.events$).next({
-			topic: THERMOSTAT_TOPIC.Target,
+			topic: THERMOSTAT_TOPIC.TargetSet,
 			type: ThermostatEventType.Message,
-			message: incomingTarget.toString()
+			message: {
+				target: incomingTarget.toString()
+			}
 		});
 
 		sinon.assert.calledWith(<any>mockThermostat.setTarget, incomingTarget);
 
 		(<Subject<IThermostatEvent>>mockIoTBridge.events$).next({
-			topic: THERMOSTAT_TOPIC.Mode,
+			topic: THERMOSTAT_TOPIC.ModeSet,
 			type: ThermostatEventType.Message,
-			message: incomingMode.toString()
+			message: {
+				mode: incomingMode.toString()
+			}
 		});
 
 		sinon.assert.calledWith(<any>mockThermostat.setMode, incomingMode.toString());

--- a/server/src/api/thermostatServer.ts
+++ b/server/src/api/thermostatServer.ts
@@ -28,7 +28,7 @@ export class ThermostatServer {
 			//broadcast events over the network
 			if(this._iotBridge) {
 				let message: any = this.buildMessageFromEvent(e);
-				this._iotBridge.broadcast(e.topic.join('/'), message);
+				this._iotBridge.broadcast(e.topic, message);
 			}
 
 			//TODO this is a hack...
@@ -160,7 +160,7 @@ export class ThermostatServer {
 		}
 	}
 
-	private emitEvent(socket: SocketIO.Socket, topic: string[], message: string) {
+	private emitEvent(socket: SocketIO.Socket, topic: string, message: string) {
 		socket.send(<IThermostatEvent>{
 			type: ThermostatEventType.Message,
 			topic: topic,

--- a/server/src/api/thermostatServer.ts
+++ b/server/src/api/thermostatServer.ts
@@ -152,10 +152,10 @@ export class ThermostatServer {
     }
 
 	private handleInboundEvent(thermostatEvent: IThermostatEvent) {
-		if(<any>thermostatEvent.topic == ThermostatTopic.Target) {
+		if(thermostatEvent.topic == ThermostatTopic.Target) {
 			this._thermostat.setTarget(parseInt(thermostatEvent.message));
 		}
-		else if(<any>thermostatEvent.topic == ThermostatTopic.Mode) {
+		else if(thermostatEvent.topic == ThermostatTopic.Mode) {
 			this._thermostat.setMode(<ThermostatMode>(<any>thermostatEvent.message))
 		}
 	}

--- a/server/src/api/thermostatServer.ts
+++ b/server/src/api/thermostatServer.ts
@@ -1,4 +1,4 @@
-import { IThermostatEvent, ThermostatEventType, ThermostatTopic } from '../../../common/thermostatEvent';
+import { IThermostatEvent, ThermostatEventType, THERMOSTAT_TOPIC } from '../../../common/thermostatEvent';
 import { ThermostatMode } from '../../../common/thermostatMode';
 
 import { IThermostat } from '../core/thermostat';
@@ -32,7 +32,7 @@ export class ThermostatServer {
 			}
 
 			//TODO this is a hack...
-			if(e.topic === ThermostatTopic.Temperature) {
+			if(e.topic === THERMOSTAT_TOPIC.Temperature) {
 				this.lastTemperature = parseFloat(e.message);
 			}
 		});
@@ -56,37 +56,37 @@ export class ThermostatServer {
     }
 
 	private buildMessageFromEvent(event: IThermostatEvent): any {
-		if(event.topic == ThermostatTopic.Temperature) {
+		if(event.topic == THERMOSTAT_TOPIC.Temperature) {
 			return {
 				temperature: parseFloat(event.message)
 			};
 		}
-		else if(event.topic == ThermostatTopic.Target) {
+		else if(event.topic == THERMOSTAT_TOPIC.Target) {
 			return {
 				target: parseInt(event.message)
 			};
 		}
-		else if(event.topic == ThermostatTopic.Mode) {
+		else if(event.topic == THERMOSTAT_TOPIC.Mode) {
 			return {
 				mode: event.message
 			};
 		}
-		else if(event.topic == ThermostatTopic.Status) {
+		else if(event.topic == THERMOSTAT_TOPIC.Status) {
 			return {
 				status: event.message
 			};
 		}
-		else if(event.topic == ThermostatTopic.Furnace) {
+		else if(event.topic == THERMOSTAT_TOPIC.Furnace) {
 			return {
 				action: event.message
 			};
 		}
-		else if(event.topic == ThermostatTopic.Ac) {
+		else if(event.topic == THERMOSTAT_TOPIC.Ac) {
 			return {
 				action: event.message
 			};
 		}
-		else if(event.topic == ThermostatTopic.Error) {
+		else if(event.topic == THERMOSTAT_TOPIC.Error) {
 			return {
 				error: event.message
 			};
@@ -98,9 +98,9 @@ export class ThermostatServer {
     private setupRoutes(socket: SocketIO.Socket) {
 
 		//emit "welcome" events to init client quickly
-		this.emitEvent(socket, ThermostatTopic.Target, this._thermostat.target.toString());
+		this.emitEvent(socket, THERMOSTAT_TOPIC.Target, this._thermostat.target.toString());
 		if(this.lastTemperature) {
-			this.emitEvent(socket, ThermostatTopic.Temperature, this.lastTemperature.toString());
+			this.emitEvent(socket, THERMOSTAT_TOPIC.Temperature, this.lastTemperature.toString());
 		}
 
 		socket.on('/reset', () => {
@@ -152,11 +152,11 @@ export class ThermostatServer {
     }
 
 	private handleInboundEvent(thermostatEvent: IThermostatEvent) {
-		if(thermostatEvent.topic == ThermostatTopic.Target) {
-			this._thermostat.setTarget(parseInt(thermostatEvent.message));
+		if(thermostatEvent.topic == THERMOSTAT_TOPIC.TargetSet) {
+			this._thermostat.setTarget(parseInt(thermostatEvent.message.target));
 		}
-		else if(thermostatEvent.topic == ThermostatTopic.Mode) {
-			this._thermostat.setMode(<ThermostatMode>(<any>thermostatEvent.message))
+		else if(thermostatEvent.topic == THERMOSTAT_TOPIC.ModeSet) {
+			this._thermostat.setMode(<ThermostatMode>(<any>thermostatEvent.message.mode));
 		}
 	}
 
@@ -171,7 +171,7 @@ export class ThermostatServer {
 	private emitError(error: string) {
 		this._io.sockets.send(<IThermostatEvent>{
 			type: ThermostatEventType.Error,
-			topic: ThermostatTopic.Error,
+			topic: THERMOSTAT_TOPIC.Error,
 			message: error,
 		});
 	}

--- a/server/src/core/thermostat.tests.ts
+++ b/server/src/core/thermostat.tests.ts
@@ -526,12 +526,9 @@ describe('Thermostat Unit Tests:', () => {
 		describe('when furnace trigger is started, it', () => {
 			it('should emit an "on" message', (done) => {
 				thermostat.start().subscribe((e: IThermostatEvent) => {
-					if(e.topic.length === 2 &&
-						e.topic[0] === 'thermostat' &&
-						e.topic[1] === 'furnace' &&
-						e.message === 'on') {
-							thermostat.stop();
-							done();
+					if(e.topic === 'thermostat/furnace' && e.message === 'on') {
+						thermostat.stop();
+						done();
 					}
 				});
 
@@ -544,12 +541,9 @@ describe('Thermostat Unit Tests:', () => {
 				
 				buildRunningThermostat(ThermostatMode.Heating).subscribe((runningThermostat) => {
 					runningThermostat.eventStream.subscribe((e: IThermostatEvent) => {
-						if(e.topic.length === 2 &&
-							e.topic[0] === 'thermostat' &&
-							e.topic[1] === 'furnace' &&
-							e.message === 'off') {
-								runningThermostat.stop();
-								done();
+						if(e.topic === 'thermostat/furnace' && e.message === 'off') {
+							runningThermostat.stop();
+							done();
 						}
 					}); 
 					(<any>thermostat).stopTrigger();
@@ -562,13 +556,10 @@ describe('Thermostat Unit Tests:', () => {
 			it('should emit an "on" message', (done) => {
 				thermostat.setMode(ThermostatMode.Cooling);
 				thermostat.start().subscribe((e: IThermostatEvent) => {
-					if(e.topic.length === 2 &&
-							e.topic[0] === 'thermostat' &&
-							e.topic[1] === 'ac' &&
-							e.message === 'on') {
-								thermostat.stop();
-								done();
-						}
+					if(e.topic === 'thermostat/ac' && e.message === 'on') {
+						thermostat.stop();
+						done();
+					}
 				});
 
 				(<any>thermostat).startTrigger();
@@ -579,12 +570,9 @@ describe('Thermostat Unit Tests:', () => {
 			it('should emit an "off" message', (done) => {
 				buildRunningThermostat(ThermostatMode.Cooling).subscribe((runningThermostat) => {
 					runningThermostat.eventStream.subscribe((e: IThermostatEvent) => {
-						if(e.topic.length === 2 &&
-							e.topic[0] === 'thermostat' &&
-							e.topic[1] === 'ac' &&
-							e.message === 'off') {
-								runningThermostat.stop();
-								done();
+						if(e.topic === 'thermostat/ac' && e.message === 'off') {
+							runningThermostat.stop();
+							done();
 						}
 					}); 
 					(<any>thermostat).stopTrigger();
@@ -603,23 +591,19 @@ describe('Thermostat Unit Tests:', () => {
 				let lastNow: number = null;
 				let msgCount = 0;
 				thermostat.eventStream.subscribe((e: IThermostatEvent) => {
+					if(e.topic === 'sensors/temperature/thermostat') {
+						let now: number = Date.now();
+						if(lastNow) {
+							let diff = Math.abs(now - lastNow);
+							expect(diff).to.be.within(tempEmitDelay-10, tempEmitDelay+10);
+						}
 
-					if(e.topic.length === 3 &&
-						e.topic[0] === 'sensors' &&
-						e.topic[1] === 'temperature' &&
-						e.topic[2] === 'thermostat') {
-							let now: number = Date.now();
-							if(lastNow) {
-								let diff = Math.abs(now - lastNow);
-								expect(diff).to.be.within(tempEmitDelay-10, tempEmitDelay+10);
-							}
+						lastNow = now;
+						msgCount++;
 
-							lastNow = now;
-							msgCount++;
-
-							if(msgCount >= iterations) {
-								done();
-							}
+						if(msgCount >= iterations) {
+							done();
+						}
 					}
 				}); 
 
@@ -636,11 +620,9 @@ describe('Thermostat Unit Tests:', () => {
 				let newTarget = thermostat.target + 2;
 
 				thermostat.eventStream.subscribe((e: IThermostatEvent) => {
-					if(e.topic.length === 2 &&
-						e.topic[0] === 'thermostat' &&
-						e.topic[1] === 'target') {
-							expect(e.message).to.equal(newTarget.toString());
-							done();
+					if(e.topic === 'thermostat/target') {
+						expect(e.message).to.equal(newTarget.toString());
+						done();
 					}
 				}); 
 				
@@ -656,10 +638,8 @@ describe('Thermostat Unit Tests:', () => {
 				let newTarget = thermostat.target;
 
 				thermostat.eventStream.subscribe((e: IThermostatEvent) => {
-					if(e.topic.length === 2 &&
-						e.topic[0] === 'thermostat' &&
-						e.topic[1] === 'target') {
-							throw new Error('Received thermostat/target message when not expected');
+					if(e.topic === 'thermostat/target') {
+						throw new Error('Received thermostat/target message when not expected');
 					}
 				}); 
 				

--- a/server/src/core/thermostat.ts
+++ b/server/src/core/thermostat.ts
@@ -1,6 +1,6 @@
 import Rx = require('rxjs');
 
-import { IThermostatEvent, ThermostatEventType, ThermostatTopic } from '../../../common/thermostatEvent';
+import { IThermostatEvent, ThermostatEventType, THERMOSTAT_TOPIC } from '../../../common/thermostatEvent';
 import { ThermostatMode } from '../../../common/thermostatMode';
 
 import { ITempReader } from './tempReader';
@@ -42,7 +42,7 @@ export class Thermostat implements IThermostat {
 		this._eventObservers = [];
         this.eventStream = Rx.Observable.create((observer: Rx.Observer<IThermostatEvent>) => {
             this._eventObservers.push(observer);
-			this.emitEvent(ThermostatEventType.Message, ThermostatTopic.Status, 'Initialized');
+			this.emitEvent(ThermostatEventType.Message, THERMOSTAT_TOPIC.Status, 'Initialized');
         }); 
     }
 
@@ -60,10 +60,10 @@ export class Thermostat implements IThermostat {
         );
 
         tempReaderObservable.throttleTime(this.configuration.tempEmitDelay).subscribe((temperature:number) => {
-            this.emitEvent(ThermostatEventType.Message, ThermostatTopic.Temperature, temperature.toString());
+            this.emitEvent(ThermostatEventType.Message, THERMOSTAT_TOPIC.Temperature, temperature.toString());
         });
 
-		this.emitEvent(ThermostatEventType.Message, ThermostatTopic.Status, 'Started');
+		this.emitEvent(ThermostatEventType.Message, THERMOSTAT_TOPIC.Status, 'Started');
 
         return this.eventStream;
     }
@@ -71,7 +71,7 @@ export class Thermostat implements IThermostat {
     stop() {
         this._tempReader.stop();
 		this.emitComplete();
-		this.emitEvent(ThermostatEventType.Message, ThermostatTopic.Status, 'Stopped');
+		this.emitEvent(ThermostatEventType.Message, THERMOSTAT_TOPIC.Status, 'Stopped');
     }
 
     private tryStartTrigger(temp: number) {
@@ -139,7 +139,7 @@ export class Thermostat implements IThermostat {
                 }
             }
 
-            this.emitEvent(ThermostatEventType.Message, ThermostatTopic.Target, target.toString());
+            this.emitEvent(ThermostatEventType.Message, THERMOSTAT_TOPIC.Target, target.toString());
         }
     }
 
@@ -156,7 +156,7 @@ export class Thermostat implements IThermostat {
         this.mode = mode;
         this.setTarget(this.defaultTarget);
         this._currentTrigger = mode === ThermostatMode.Heating ? this._furnaceTrigger : this._acTrigger;
-		this.emitEvent(ThermostatEventType.Message, ThermostatTopic.Mode, mode.toString());
+		this.emitEvent(ThermostatEventType.Message, THERMOSTAT_TOPIC.Mode, mode.toString());
     }
 
     private targetIsWithinBounds(target: number) {
@@ -177,7 +177,7 @@ export class Thermostat implements IThermostat {
 
     private emitTriggerEvent(start: boolean) {
         let topic = this.mode === ThermostatMode.Heating ? 
-							ThermostatTopic.Furnace : ThermostatTopic.Ac;
+							THERMOSTAT_TOPIC.Furnace : THERMOSTAT_TOPIC.Ac;
         let value = start ? 'on' : 'off';
 
         this.emitEvent(ThermostatEventType.Message, topic, value);

--- a/server/src/core/thermostat.ts
+++ b/server/src/core/thermostat.ts
@@ -183,7 +183,7 @@ export class Thermostat implements IThermostat {
         this.emitEvent(ThermostatEventType.Message, topic, value);
     }
 
-    private emitEvent(type: ThermostatEventType, topic: Array<string>, message: string) {
+    private emitEvent(type: ThermostatEventType, topic: string, message: string) {
         if(this._eventObservers) {
             this._eventObservers.forEach((observer) => {
 				observer.next({


### PR DESCRIPTION
Arrays were just too hard to manage and compare against each other, so moving these to simple strings.

Also...before the code was subscribing to the wildcard thermostat/# topic. This changes the code to be more explicit, and includes subscribing to the '/set' set of topics. Using these helps avoid MQTT loops by putting sets on their own topic.