### PR TITLE
Properly convert string -> enum

### DIFF
--- a/server/src/api/thermostatServer.tests.ts
+++ b/server/src/api/thermostatServer.tests.ts
@@ -227,9 +227,8 @@ describe('Thermostat Server Spec', () => {
 		});
 	});
 
-	it('should listen to the iot bridge and forward messages to thermostat', () => {
+	it('should listen to the iot bridge and forward target messages to thermostat', () => {
 		let incomingTarget = 74;
-		let incomingMode = ThermostatMode.Cooling;
 
 		(<Subject<IThermostatEvent>>mockIoTBridge.events$).next({
 			topic: THERMOSTAT_TOPIC.TargetSet,
@@ -240,16 +239,18 @@ describe('Thermostat Server Spec', () => {
 		});
 
 		sinon.assert.calledWith(<any>mockThermostat.setTarget, incomingTarget);
+	});
 
+	it('should listen to the iot bridge and forward mode messages to thermostat', () => {
 		(<Subject<IThermostatEvent>>mockIoTBridge.events$).next({
 			topic: THERMOSTAT_TOPIC.ModeSet,
 			type: ThermostatEventType.Message,
 			message: {
-				mode: incomingMode.toString()
+				mode: "Cooling"
 			}
 		});
 
-		sinon.assert.calledWith(<any>mockThermostat.setMode, incomingMode.toString());
+		sinon.assert.calledWith(<any>mockThermostat.setMode, ThermostatMode.Cooling);
 	});
 
 	it('should start and stop fan when message received from iot bridge', () => {

--- a/server/src/api/thermostatServer.ts
+++ b/server/src/api/thermostatServer.ts
@@ -159,7 +159,7 @@ export class ThermostatServer {
 			this._thermostat.setTarget(parseInt(thermostatEvent.message.target));
 		}
 		else if(thermostatEvent.topic == THERMOSTAT_TOPIC.ModeSet) {
-			this._thermostat.setMode(<ThermostatMode>(<any>thermostatEvent.message.mode));
+			this._thermostat.setMode(ThermostatMode[<string>thermostatEvent.message.mode]);
 		}
 		else if(thermostatEvent.topic == THERMOSTAT_TOPIC.FanSet) {
 			if(thermostatEvent.message.fan === 'start') {

--- a/server/src/core/thermostat.ts
+++ b/server/src/core/thermostat.ts
@@ -164,6 +164,12 @@ export class Thermostat implements IThermostat {
 				break;
 			case ThermostatMode.Off:
 				this._currentTrigger = null;
+				break;
+			default:
+				this.emitEvent(ThermostatEventType.Message, 
+							THERMOSTAT_TOPIC.Error, 
+							`Unknown mode received: ${mode}`);
+				return;
 		}
 
         this.mode = mode;


### PR DESCRIPTION
The conversion was failing in the server, resulting in settings the mode to "0" or "1" instead of the actualy enum value. Fixed the test to properly test this (it was not testing right) and added a bit to the thermostat to send out an error on the IoT bridge if it gets anything other than the expected enum values.