### PR TITLE
Add one schedule per mode

### DIFF
--- a/server/src/api/configuration.ts
+++ b/server/src/api/configuration.ts
@@ -19,10 +19,15 @@ export interface IScheduleItem {
 	temperature: number;
 }
 
-export interface IScheduleConfiguration {
-	timezone: string;
+export interface IWeeklySchedule {
 	weekdays: Array<IScheduleItem>;
 	weekends: Array<IScheduleItem>;
+}
+
+export interface IScheduleConfiguration {
+	timezone: string;
+	heating: IWeeklySchedule;
+	cooling: IWeeklySchedule;	
 }
 
 export interface IPinConfiguration {

--- a/server/src/api/schedule.tests.ts
+++ b/server/src/api/schedule.tests.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon';
 var expect = chai.expect;
 
 import { IScheduleConfiguration, IScheduleItem } from './configuration';
+import { ThermostatMode } from '../../../common/thermostatMode';
 import { Scheduler } from './schedule';
 
 describe('Schedule Unit Tests:', () => {
@@ -14,80 +15,163 @@ describe('Schedule Unit Tests:', () => {
 	const DATE_SATURDAY: Date = new Date(2016, 10, 19);
 	const DATE_SUNDAY: Date = new Date(2016, 10, 20);
 
-	let scheduleConfig: IScheduleConfiguration;
+	let schedule: IScheduleConfiguration;
 	let scheduler: Scheduler;
 	let clock: sinon.SinonFakeTimers;
 	let callback: sinon.SinonSpy;
 
-	beforeEach(() => {
-		scheduleConfig = {
-			timezone: 'America/New_York',
-			weekdays: [
-				{ time: "6:00", temperature: 68 },
-				{ time: "7:30", temperature: 63 },
-				{ time: "16:00", temperature: 68 },
-				{ time: "22:00", temperature: 63 }
-			],
-			weekends: [
-				{ time: "7:00", temperature: 68 },
-				{ time: "22:00", temperature: 63 }
-			]
-		};
+	describe('heating schedule', () => {
+		beforeEach(() => {
 
-		scheduler = new Scheduler(scheduleConfig);
+			schedule = {
+				timezone: "America/New_York",
+				heating: {
+					weekdays: [
+						{ time: "6:00", temperature: 68 },
+						{ time: "7:30", temperature: 63 },
+						{ time: "16:00", temperature: 68 },
+						{ time: "22:00", temperature: 63 }
+					],
+					weekends: [
+						{ time: "7:00", temperature: 68 },
+						{ time: "22:00", temperature: 63 }
+					]
+				},
+				cooling: {
+					weekdays: [],
+					weekends: []
+				}
+			}
+
+			scheduler = new Scheduler(schedule);
+		});
+
+		afterEach(() => {
+			if(clock) {
+				clock.restore();
+			}
+		});
+
+		it('should schedule all weekday temperature changes on Monday', (done) => {
+			clock = sinon.useFakeTimers(DATE_MONDAY.getTime());
+			testSchedule(ThermostatMode.Heating, schedule.heating.weekdays);
+			done();
+		});
+
+		it('should schedule all weekday temperature changes on Tuesday', (done) => {
+			clock = sinon.useFakeTimers(DATE_TUESDAY.getTime());
+			testSchedule(ThermostatMode.Heating, schedule.heating.weekdays);
+			done();
+		});
+
+		it('should schedule all weekday temperature changes on Wednesday', (done) => {
+			clock = sinon.useFakeTimers(DATE_WEDNESDAY.getTime());
+			testSchedule(ThermostatMode.Heating, schedule.heating.weekdays);
+			done();
+		});
+
+		it('should schedule all weekday temperature changes on Thursday', (done) => {
+			clock = sinon.useFakeTimers(DATE_THURSDAY.getTime());
+			testSchedule(ThermostatMode.Heating, schedule.heating.weekdays);
+			done();
+		});
+
+		it('should schedule all weekday temperature changes on Friday', (done) => {
+			clock = sinon.useFakeTimers(DATE_FRIDAY.getTime());
+			testSchedule(ThermostatMode.Heating, schedule.heating.weekdays);
+			done();
+		});
+
+		it('should schedule all weekend temperature changes on Saturday', (done) => {
+			clock = sinon.useFakeTimers(DATE_SATURDAY.getTime());
+			testSchedule(ThermostatMode.Heating, schedule.heating.weekends);
+			done();
+		});
+
+		it('should schedule all weekend temperature changes on Sunday', (done) => {
+			clock = sinon.useFakeTimers(DATE_SUNDAY.getTime());
+			testSchedule(ThermostatMode.Heating, schedule.heating.weekends);
+			done();
+		});
 	});
 
-	afterEach(() => {
-		if(clock) {
-			clock.restore();
-		}
+	describe('cooling schedule', () => {
+		beforeEach(() => {
+
+			schedule = {
+				timezone: "America/New_York",
+				heating: {
+					weekdays: [],
+					weekends: []
+				},
+				cooling: {
+					weekdays: [
+						{ time: "6:00", temperature: 72 },
+						{ time: "7:30", temperature: 75 },
+						{ time: "16:00", temperature: 71 },
+					],
+					weekends: [
+						{ time: "7:00", temperature: 70 },
+						{ time: "22:00", temperature: 75 }
+					]
+				}
+			}
+
+			scheduler = new Scheduler(schedule);
+		});
+
+		afterEach(() => {
+			if(clock) {
+				clock.restore();
+			}
+		});
+
+		it('should schedule all weekday temperature changes on Monday', (done) => {
+			clock = sinon.useFakeTimers(DATE_MONDAY.getTime());
+			testSchedule(ThermostatMode.Cooling, schedule.cooling.weekdays);
+			done();
+		});
+
+		it('should schedule all weekday temperature changes on Tuesday', (done) => {
+			clock = sinon.useFakeTimers(DATE_TUESDAY.getTime());
+			testSchedule(ThermostatMode.Cooling, schedule.cooling.weekdays);
+			done();
+		});
+
+		it('should schedule all weekday temperature changes on Wednesday', (done) => {
+			clock = sinon.useFakeTimers(DATE_WEDNESDAY.getTime());
+			testSchedule(ThermostatMode.Cooling, schedule.cooling.weekdays);
+			done();
+		});
+
+		it('should schedule all weekday temperature changes on Thursday', (done) => {
+			clock = sinon.useFakeTimers(DATE_THURSDAY.getTime());
+			testSchedule(ThermostatMode.Cooling, schedule.cooling.weekdays);
+			done();
+		});
+
+		it('should schedule all weekday temperature changes on Friday', (done) => {
+			clock = sinon.useFakeTimers(DATE_FRIDAY.getTime());
+			testSchedule(ThermostatMode.Cooling, schedule.cooling.weekdays);
+			done();
+		});
+
+		it('should schedule all weekend temperature changes on Saturday', (done) => {
+			clock = sinon.useFakeTimers(DATE_SATURDAY.getTime());
+			testSchedule(ThermostatMode.Cooling, schedule.cooling.weekends);
+			done();
+		});
+
+		it('should schedule all weekend temperature changes on Sunday', (done) => {
+			clock = sinon.useFakeTimers(DATE_SUNDAY.getTime());
+			testSchedule(ThermostatMode.Cooling, schedule.cooling.weekends);
+			done();
+		});
 	});
 
-	it('should schedule all weekday temperature changes on Monday', (done) => {
-		clock = sinon.useFakeTimers(DATE_MONDAY.getTime());
-		testSchedule(scheduleConfig.weekdays);
-		done();
-	});
-
-	it('should schedule all weekday temperature changes on Tuesday', (done) => {
-		clock = sinon.useFakeTimers(DATE_TUESDAY.getTime());
-		testSchedule(scheduleConfig.weekdays);
-		done();
-	});
-
-	it('should schedule all weekday temperature changes on Wednesday', (done) => {
-		clock = sinon.useFakeTimers(DATE_WEDNESDAY.getTime());
-		testSchedule(scheduleConfig.weekdays);
-		done();
-	});
-
-	it('should schedule all weekday temperature changes on Thursday', (done) => {
-		clock = sinon.useFakeTimers(DATE_THURSDAY.getTime());
-		testSchedule(scheduleConfig.weekdays);
-		done();
-	});
-
-	it('should schedule all weekday temperature changes on Friday', (done) => {
-		clock = sinon.useFakeTimers(DATE_FRIDAY.getTime());
-		testSchedule(scheduleConfig.weekdays);
-		done();
-	});
-
-	it('should schedule all weekend temperature changes on Saturday', (done) => {
-		clock = sinon.useFakeTimers(DATE_SATURDAY.getTime());
-		testSchedule(scheduleConfig.weekends);
-		done();
-	});
-
-	it('should schedule all weekend temperature changes on Sunday', (done) => {
-		clock = sinon.useFakeTimers(DATE_SUNDAY.getTime());
-		testSchedule(scheduleConfig.weekends);
-		done();
-	});
-
-	function testSchedule(scheduleItems: IScheduleItem[]) {
+	function testSchedule(mode: ThermostatMode, scheduleItems: IScheduleItem[]) {
 		callback = sinon.spy();
-		scheduler.initSchedule(callback);
+		scheduler.initSchedule(mode, callback);
 
 		let callCount = 0;
 		let lastItemMillis: number = 0;

--- a/server/src/api/schedule.ts
+++ b/server/src/api/schedule.ts
@@ -1,26 +1,43 @@
 import * as cron from 'cron';
 
-import { IScheduleConfiguration, IScheduleItem } from './configuration';
+import { IScheduleConfiguration, IScheduleItem, IWeeklySchedule } from './configuration';
+import { ThermostatMode } from "../../../common/thermostatMode";
 
 export interface IScheduler {
-	initSchedule: {(callback: {(temperature)})};
+	initSchedule: {(mode: ThermostatMode, callback: {(temperature)})};
 }
 
 export class Scheduler implements IScheduler {
-	constructor(private _schedule: IScheduleConfiguration) {}
+	private _currentWeeklySchedule: IWeeklySchedule;
+	private _cronJobs: cron.CronJob[];
 
-	initSchedule(callback: {(temperature): void}) {
-		this._schedule.weekdays.forEach((item) => {
+	constructor(private _schedule: IScheduleConfiguration) {
+		this._cronJobs = [];
+	}
+
+	initSchedule(mode: ThermostatMode, callback: {(temperature): void}) {
+		this.clearExistingJobs();
+		this._currentWeeklySchedule = mode === ThermostatMode.Heating ?
+							this._schedule.heating : this._schedule.cooling;
+
+		this._currentWeeklySchedule.weekdays.forEach((item) => {
 			this.initCronJob(item, 'MON-FRI', callback);
 		});
 
-		this._schedule.weekends.forEach((item) => {
+		this._currentWeeklySchedule.weekends.forEach((item) => {
 			this.initCronJob(item, 'SAT,SUN', callback);
 		});
 	}
 
+	private clearExistingJobs() {
+		this._cronJobs.forEach((cronJob) => {
+			cronJob.stop();
+		});
+		this._cronJobs = [];
+	}
+
 	private initCronJob(item: IScheduleItem, days: string, callback: {(temperature): void}) {
-		new cron.CronJob({
+		let cronJob = new cron.CronJob({
 			cronTime: this.buildCronString(item.time, days),
 			onTick: () => {
 				callback(item.temperature);
@@ -28,6 +45,8 @@ export class Scheduler implements IScheduler {
 			start: true,
 			timeZone: this._schedule.timezone
 		});
+
+		this._cronJobs.push(cronJob);
 	}
 	
 	private buildCronString(strTime: string, dayOfWeek: string) {

--- a/server/src/api/thermostatServer.tests.ts
+++ b/server/src/api/thermostatServer.tests.ts
@@ -74,7 +74,7 @@ describe('Thermostat Server Spec', () => {
 
 		onScheduleCallback = sinon.spy();
 		mockScheduler = {
-			initSchedule: (callback) => {
+			initSchedule: (mode: ThermostatMode, callback) => {
 				onScheduleCallback = callback;
 			}
 		};
@@ -344,5 +344,20 @@ describe('Thermostat Server Spec', () => {
 		mockSocketEvents.find((event) => event.key === '/mode').callback({mode: mode});
 
 		sinon.assert.calledWith(<any>mockThermostat.setMode, mode);
+	});
+
+	it('should re-initialize scheduler when thermostat emits a mode change event', () => {
+		mockThermostat.mode = ThermostatMode.Cooling;
+		mockScheduler.initSchedule = sinon.spy();
+
+		let event: IThermostatEvent = {
+			type: ThermostatEventType.Message,
+			topic: THERMOSTAT_TOPIC.Mode,
+			message: 'heating'
+		};
+		mockEventStream.next(event);
+
+		sinon.assert.calledWith(<any>mockScheduler.initSchedule,
+								ThermostatMode.Cooling);
 	});
 });

--- a/server/src/api/thermostatServer.ts
+++ b/server/src/api/thermostatServer.ts
@@ -35,6 +35,11 @@ export class ThermostatServer {
 			if(event.topic === THERMOSTAT_TOPIC.Temperature) {
 				this.lastTemperatureMessage = event.message;
 			}
+
+			if(event.topic === THERMOSTAT_TOPIC.Mode) {
+				//need to change heating/cooling schedules when mode changes
+				this.initScheduler();
+			}
 		});
 
 		if(this._iotBridge) {
@@ -46,14 +51,18 @@ export class ThermostatServer {
 
 		this._thermostat.start();
 
-		if(this._scheduler) {
-			this._scheduler.initSchedule((temperature) => {
-				this._thermostat.setTarget(temperature);
-			});
-		}
+		this.initScheduler();
 
 		console.log('Server started!');
     }
+
+	private initScheduler() {
+		if(this._scheduler) {
+			this._scheduler.initSchedule(this._thermostat.mode, (temperature) => {
+				this._thermostat.setTarget(temperature);
+			});
+		}
+	}
 
 	private buildMessageFromEvent(event: IThermostatEvent): any {
 		if(event.topic == THERMOSTAT_TOPIC.Temperature) {

--- a/server/thermostat.config.json
+++ b/server/thermostat.config.json
@@ -28,15 +28,28 @@
 	},
 	"schedule": {
 		"timezone": "America/New_York",
-		"weekdays": [
-			{ "time": "6:00", "temperature": 68 },
-			{ "time": "7:30", "temperature": 63 },
-			{ "time": "16:00", "temperature": 68 },
-			{ "time": "22:00", "temperature": 63 }
-		],
-		"weekends": [
-			{ "time": "7:00", "temperature": 68 },
-			{ "time": "22:00", "temperature": 63 }
-		]
+		"heating": {
+			"weekdays": [
+				{ "time": "6:00", "temperature": 68 },
+				{ "time": "7:30", "temperature": 63 },
+				{ "time": "16:00", "temperature": 68 },
+				{ "time": "22:00", "temperature": 63 }
+			],
+			"weekends": [
+				{ "time": "7:00", "temperature": 68 },
+				{ "time": "22:00", "temperature": 63 }
+			]
+		},
+		"cooling": {
+			"weekdays": [
+				{ "time": "6:00", "temperature": 78 },
+				{ "time": "16:00", "temperature": 74 },
+				{ "time": "22:00", "temperature": 76 }
+			],
+			"weekends": [
+				{ "time": "7:00", "temperature": 74 },
+				{ "time": "22:00", "temperature": 78 }
+			]
+		}
 	}
 }


### PR DESCRIPTION
Previously one schedule was used for both heating and cooling. In practice, this isn't ideal as the schedules for each of these modes will almost always be different. This adds the ability to have a separate schedule for both heating and cooling. The scheduler now takes a schedule object that contains both heating/cooling schedules and the server passes in the correct mode to pick. The server watches for mode changes and re-initializes the schedule when this happens.