### PR TITLE
Properly convert mode enum to string

### DIFF
--- a/server/src/core/thermostat.ts
+++ b/server/src/core/thermostat.ts
@@ -175,7 +175,7 @@ export class Thermostat implements IThermostat {
         this.mode = mode;
         this.setTarget(this.defaultTarget);
         
-		this.emitEvent(ThermostatEventType.Message, THERMOSTAT_TOPIC.Mode, mode.toString());
+		this.emitEvent(ThermostatEventType.Message, THERMOSTAT_TOPIC.Mode, ThermostatMode[mode]);
     }
 
     private targetIsWithinBounds(target: number) {


### PR DESCRIPTION
`.toString()` returns the integer value. We want the string name so we need to index into the enum instead.